### PR TITLE
add support for visual-regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,4 @@ Apropospriate supports all the usual `prog-mode` derived packages as well as som
 * Hi-Lock
 * Flyspell
 * Display Numbers Line Mode
+* Visual-Regexp

--- a/apropospriate.el
+++ b/apropospriate.el
@@ -639,7 +639,13 @@ Set to `1.0' or nil to prevent font size manipulation."
      `(hi-blue-b ((,class (:inherit hi-blue :bold t))))
      `(hi-green-b ((,class (:inherit hi-green :bold t))))
      `(hi-red-b ((,class (:inherit highlight :foreground ,red :inverse-video t :bold t))))
-     `(hi-black-hb ((,class (:inherit hi-black-b :height 1.2)))))
+     `(hi-black-hb ((,class (:inherit hi-black-b :height 1.2))))
+     `(vr/match-0 ((,class (:background ,teal))))
+     `(vr/match-1 ((,class (:background ,teal-1))))
+     `(vr/group-0 ((,class (:background ,blue))))
+     `(vr/group-1 ((,class (:background ,indigo))))
+     `(vr/group-2 ((,class (:background ,purple))))
+     `(vr/match-separator-face ((,class (:foreground ,red :bold t)))))
 
     (custom-theme-set-variables
      theme-name

--- a/apropospriate.el
+++ b/apropospriate.el
@@ -640,11 +640,11 @@ Set to `1.0' or nil to prevent font size manipulation."
      `(hi-green-b ((,class (:inherit hi-green :bold t))))
      `(hi-red-b ((,class (:inherit highlight :foreground ,red :inverse-video t :bold t))))
      `(hi-black-hb ((,class (:inherit hi-black-b :height 1.2))))
-     `(vr/match-0 ((,class (:background ,teal))))
-     `(vr/match-1 ((,class (:background ,teal-1))))
-     `(vr/group-0 ((,class (:background ,blue))))
-     `(vr/group-1 ((,class (:background ,indigo))))
-     `(vr/group-2 ((,class (:background ,purple))))
+     `(vr/match-0 ((,class (:background ,light-emphasis-1))))
+     `(vr/match-1 ((,class (:background ,light-emphasis-2))))
+     `(vr/group-0 ((,class (:foreground ,red :bold t))))
+     `(vr/group-1 ((,class (:foreground ,orange :bold t))))
+     `(vr/group-2 ((,class (:foreground ,green :bold t))))
      `(vr/match-separator-face ((,class (:foreground ,red :bold t)))))
 
     (custom-theme-set-variables


### PR DESCRIPTION
I'm conflicted for `vr/group-*` faces between a red-orange-yellow color trio or using the current setup of blue-indigo-purple trio. I like the "bluer" scheme more, but I can change it if you don't like it.