### PR TITLE
Add yafolding ellipsis face

### DIFF
--- a/apropospriate.el
+++ b/apropospriate.el
@@ -657,7 +657,8 @@ Set to `1.0' or nil to prevent font size manipulation."
      `(vr/group-0 ((,class (:foreground ,red :bold t))))
      `(vr/group-1 ((,class (:foreground ,orange :bold t))))
      `(vr/group-2 ((,class (:foreground ,green :bold t))))
-     `(vr/match-separator-face ((,class (:foreground ,red :bold t)))))
+     `(vr/match-separator-face ((,class (:foreground ,red :bold t))))
+     `(yafolding-ellipsis-face ((,class (:inherit font-lock-comment-face)))))
 
     (custom-theme-set-variables
      theme-name


### PR DESCRIPTION
This PR themes the ellipsis (`[…]`) overlays added by the yafolding package to folded code blocks.
It simply inherits the `font-lock-comment` face, and looks like this :

- light 
  <img width="195" alt="light" src="https://user-images.githubusercontent.com/850396/71251334-5c24d780-2322-11ea-85e0-57c54f96a227.png">

- dark
   <img width="196" alt="dark" src="https://user-images.githubusercontent.com/850396/71251336-5cbd6e00-2322-11ea-90f3-b5b93a0a5cfa.png">
