### PR TITLE
Fix emacs 30 warning

### DIFF
--- a/apropospriate-theme.el
+++ b/apropospriate-theme.el
@@ -104,7 +104,7 @@ Set to `1.0' or nil to prevent font size manipulation."
      `(trailing-whitespace ((,class (:background ,base00+1 :foreground ,yellow))))
      `(next-error ((,class (:background ,base01))))
      `(secondary-selection ((,class (:background ,base00-1))))
-     `(header-line ((,class (:foreground ,purple :background nil))))
+     `(header-line ((,class (:foreground ,purple :background 'unspecified))))
      `(auto-dim-other-buffers-face ((,class (:background ,base00+1))))
      `(fringe ((,class (:background ,base00 :foreground ,base02))))
      `(mistty-fringe-face ((,class (:foreground ,base01))))


### PR DESCRIPTION
in emacs 30, i'm getting:

```
Warning: setting attribute ‘:background’ of face ‘header-line’: nil value is invalid, use ‘unspecified’ instead.
```

I think unspecified will have the same effect.