### PR TITLE
Set lexical-binding: t

### DIFF
--- a/apropospriate-theme.el
+++ b/apropospriate-theme.el
@@ -1,4 +1,4 @@
-;;; apropospriate-theme.el --- A light & dark theme set for Emacs.
+;;; apropospriate-theme.el --- A light & dark theme set for Emacs.  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015 Justin Talbott
 


### PR DESCRIPTION
Without it, you get a warning in Emacs 31 that looks like:

⛔ Warning (files): Missing ‘lexical-binding’ cookie in "apropospriate-theme.el". You can add one with ‘M-x elisp-enable-lexical-binding RET’. See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’ for more information.